### PR TITLE
feat: load settings from env file

### DIFF
--- a/fetch_config.py
+++ b/fetch_config.py
@@ -1,7 +1,6 @@
 # fetch_config.py
-import os
-from pathlib import Path
 from pydantic_settings import BaseSettings
+from pydantic import ConfigDict
 
 class Settings(BaseSettings):
     # Azure / Graph API
@@ -14,9 +13,11 @@ class Settings(BaseSettings):
     # The root folder name under which jobs are organized
     root_folder_name: str = "2024 Jobs"
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    # load from .env file
+    model_config = ConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
 
 # instantiate at import time
 settings = Settings()


### PR DESCRIPTION
## Summary
- load configuration from a `.env` file using Pydantic's `ConfigDict`
- keep existing `root_folder_name` default

## Testing
- `python -m py_compile fetch_config.py`
- `TENANT_ID=foo CLIENT_ID=bar CLIENT_SECRET=baz USER_ID=qux python - <<'PY'
from fetch_config import settings
print(settings)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894b0709ce0832f99814598cf9f84d4